### PR TITLE
some initial changes to add support for getting starting_points for forks

### DIFF
--- a/retreat_gem/bin/retreat
+++ b/retreat_gem/bin/retreat
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+$: << File.dirname(__FILE__)+'/../lib'
+
 require 'coderetreat/retreat'
 
 include CodeRetreat

--- a/retreat_gem/bin/retreat
+++ b/retreat_gem/bin/retreat
@@ -38,11 +38,11 @@ action = ARGV.shift
 begin
   case
     when action == "info"
-      Actions::Info.run!
+      Actions::Info.run!(ARGV)
     when action == "install"
-      Actions::Install.run!
+      Actions::Install.run!(ARGV)
     when action == "update"
-      Actions::Update.run!
+      Actions::Update.run!(ARGV)
     when action == "start"
       Actions::Start.run!(ARGV)      
     else

--- a/starting_points/intercal/readme.txt
+++ b/starting_points/intercal/readme.txt
@@ -1,0 +1,3 @@
+Good luck.
+
+You're really going to need it.


### PR DESCRIPTION
Install now accepts an optional gh username and will clone that user's coderetreat repo instead of coreyhaines/coderetreat.

Likewise with update.

The start command accepts a language in the format "user/language" which will use the github.com/user/coderetreat repository instead of the default.

The install action is now pretty much redundant since start will try to clone any repo that is not already there.

There's quite a bit of cleanup i'd like to do.  Let me know if you'd like that done first. 
