### PR TITLE
Making the default ruby spec to be a failing spec.

### DIFF
--- a/starting_points/ruby/spec/conways_spec.rb
+++ b/starting_points/ruby/spec/conways_spec.rb
@@ -3,6 +3,6 @@ require 'conways'
 
 describe "conways" do
   it "is a game of life" do
-    
+    false.should be_true
   end
 end


### PR DESCRIPTION
My preference is to always have a failing test to start.  Also i noticed that the Java starting point has a failing test - so i think that this will be consistent.
